### PR TITLE
example: Fix working directory path

### DIFF
--- a/webrender/examples/demo.rs
+++ b/webrender/examples/demo.rs
@@ -9,6 +9,8 @@ use sdl2::mouse::MouseButton;
 
 use std::thread;
 use std::time::Duration;
+use std::env;
+use std::fs;
 
 const TARGET_FPS: u32 = 60;
 
@@ -16,7 +18,6 @@ struct TestLoader;
 
 impl stylish_webrender::Assets for TestLoader {
     fn load_font(&self, name: &str) -> Option<Vec<u8>> {
-        use std::fs;
         use std::io::Read;
         let mut file = if let Ok(f) = fs::File::open(format!("res/{}.ttf", name)) {
             f
@@ -26,7 +27,6 @@ impl stylish_webrender::Assets for TestLoader {
         Some(data)
     }
     fn load_image(&self, name: &str) -> Option<stylish_webrender::Image> {
-        use std::fs;
         use std::io::BufReader;
         let file = BufReader::new(if let Ok(f) = fs::File::open(format!("res/{}.png", name)) {
             f
@@ -90,6 +90,10 @@ fn main() {
     window.gl_make_current(&context).unwrap();
 
     let mut manager = stylish::Manager::new();
+
+    if fs::metadata("./res").ok().map_or(true, |v| !v.is_dir()) {
+        env::set_current_dir("../").unwrap();
+    }
 
     let mut renderer = stylish_webrender::WebRenderer::new(
         |n| video_subsystem.gl_get_proc_address(n),


### PR DESCRIPTION
The resource folder is in the root folder of the repo. Paths are relative to ./webrender. This is fixed by setting the working directory to the repo root.