### PR TITLE
cargo upgrade --all + fixed build errors.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,17 @@
 [package]
+authors = ["Matthew Collins <thethinkofdeath@gmail.com>"]
 name = "stylish"
 version = "0.1.0"
-authors = ["Matthew Collins <thethinkofdeath@gmail.com>"]
+
+[dependencies]
+error-chain = "0.11.0"
+fnv = "1.0.6"
+
+[dependencies.stylish_syntax]
+path = "./syntax"
 
 [workspace]
 members = [
     "./syntax",
-    "./webrender"
+    "./webrender",
 ]
-
-[dependencies]
-stylish_syntax = { path = "./syntax" }
-error-chain = "0.11.0"
-fnv = "1.0.5"

--- a/syntax/Cargo.toml
+++ b/syntax/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
+authors = ["Matthew Collins <thethinkofdeath@gmail.com>"]
 name = "stylish_syntax"
 version = "0.1.0"
-authors = ["Matthew Collins <thethinkofdeath@gmail.com>"]
 
 [dependencies]
-combine = "2.3.2"
-fnv = "1.0.5"
+combine = "2.5.2"
+fnv = "1.0.6"

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,24 +1,26 @@
 [package]
+authors = ["Matthew Collins <thethinkofdeath@gmail.com>"]
 name = "stylish_webrender"
 version = "0.1.0"
-authors = ["Matthew Collins <thethinkofdeath@gmail.com>"]
+
+[dependencies]
+app_units = "0.5.6"
+euclid = "0.15.5"
+gleam = "0.4.14"
+stb_truetype = "0.2.1"
+
+[dependencies.stylish]
+path = "../"
+
+[dependencies.webrender]
+default-features = false
+features = ["freetype-lib"]
+git = "https://github.com/servo/webrender"
+rev = "ab5a1b89"
+
+[dev-dependencies]
+glutin = "0.10.1"
+image = "0.17.0"
 
 [features]
 debugger = ["webrender/debugger"]
-
-[dependencies]
-stylish = { path = "../" }
-gleam = "0.4.3"
-app_units = "0.5"
-stb_truetype = "0.2.1"
-euclid = "0.15"
-
-[dev-dependencies]
-glutin = "0.9"
-image = "0.13.0"
-
-[dependencies.webrender]
-git = "https://github.com/servo/webrender"
-rev = "8a39cf24f493e894a66c2465dd310a2b2923e558"
-default-features = false
-features = [ "freetype-lib" ]

--- a/webrender/examples/demo.rs
+++ b/webrender/examples/demo.rs
@@ -292,6 +292,12 @@ top_bar > rust_logo {
     width = 56,
     height = 56,
     image = "rust-logo-64",
+    filters = filters(
+        "sepia", 0.99,
+        "brightness", 0.35,
+        "hue_rotate", 350.0,
+        "saturate", 25.0
+    ),
 }
 
 top_bar > @text {

--- a/webrender/src/filter.rs
+++ b/webrender/src/filter.rs
@@ -32,7 +32,10 @@ pub fn filters(params: Vec<stylish::Value>) -> stylish::SResult<stylish::Value> 
                 "grayscale" => Ok(FilterOp::Grayscale(op)),
                 "hue_rotate" => Ok(FilterOp::HueRotate(op)),
                 "invert" => Ok(FilterOp::Invert(op)),
-                "opacity" => Ok(FilterOp::Opacity(PropertyBinding::Value(op))),
+
+                /// TODO: Review this, seems to have something to do with animation?
+                "opacity" => Ok(FilterOp::Opacity(PropertyBinding::Value(op), op)),
+
                 "saturate" => Ok(FilterOp::Saturate(op)),
                 "sepia" => Ok(FilterOp::Sepia(op)),
                 _ => Err(ErrorKind::Msg("Invalid filter".into())),

--- a/webrender/src/filter.rs
+++ b/webrender/src/filter.rs
@@ -32,10 +32,7 @@ pub fn filters(params: Vec<stylish::Value>) -> stylish::SResult<stylish::Value> 
                 "grayscale" => Ok(FilterOp::Grayscale(op)),
                 "hue_rotate" => Ok(FilterOp::HueRotate(op)),
                 "invert" => Ok(FilterOp::Invert(op)),
-
-                /// TODO: Review this, seems to have something to do with animation?
                 "opacity" => Ok(FilterOp::Opacity(PropertyBinding::Value(op), op)),
-
                 "saturate" => Ok(FilterOp::Saturate(op)),
                 "sepia" => Ok(FilterOp::Sepia(op)),
                 _ => Err(ErrorKind::Msg("Invalid filter".into())),
@@ -45,6 +42,10 @@ pub fn filters(params: Vec<stylish::Value>) -> stylish::SResult<stylish::Value> 
 
         filters.push(filter);
     }
+    
+    // TODO: Investigate why the filter order needs to be reversed after the
+    // webrender upgrade.
+    filters.reverse();
 
     Ok(stylish::Value::Any(Box::new(Filters(filters))))
 }

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -46,7 +46,7 @@ type WResult<T> = Result<T, Box<Error>>;
 ///                        in decimal 0-255.
 pub struct WebRenderer<A> {
     assets: Rc<A>,
-    renderer: Option<Renderer<'static>>, // TODO: Review lifetime. I'm getting unexpected borrowing errors for manager if declaring 'a on WebRenderer and using it here.
+    renderer: Option<Renderer<'static>>,
     api: RenderApi,
     document: DocumentId,
     frame_id: Epoch,

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -46,7 +46,7 @@ type WResult<T> = Result<T, Box<Error>>;
 ///                        in decimal 0-255.
 pub struct WebRenderer<A> {
     assets: Rc<A>,
-    renderer: Option<Renderer>,
+    renderer: Option<Renderer<'static>>, // TODO: Review lifetime. I'm getting unexpected borrowing errors for manager if declaring 'a on WebRenderer and using it here.
     api: RenderApi,
     document: DocumentId,
     frame_id: Epoch,


### PR DESCRIPTION
Hi,

This seems to be a really cool project :) Is there some kind of a road map? I've been on a GUI framework hunt for Rust for quite some time now and this is by far the most promising I've found yet, primarily due to webrender being so active, reusing that code seems brilliant. The high frame rate and low CPU usage of the demo looks promising too.

I used `cargo upgrade --all` and in addition to upgrading all dependencies it also reordered some parts of the toml files.

I was going to take a stab at a resizing bug on macOS as an introduction to the code but wanted to upgrade all dependencies first to avoid hunting something that was solved upstream. That bug is still crawling though. 🐛 

There are comments added at two of the changes that would be good to review.