### PR TITLE
syntax: fix for nightly recursion limit

### DIFF
--- a/syntax/src/lib.rs
+++ b/syntax/src/lib.rs
@@ -1,4 +1,4 @@
-
+#![recursion_limit="128"]
 extern crate combine;
 extern crate fnv;
 


### PR DESCRIPTION
Fixes compiler error on latest nightly caused by the recursion limit in the syntax crate.